### PR TITLE
feat: add a new route /explorer/constructor_args/address for returning the constructor args used during deployment

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,9 +7,12 @@ import os
 import diskcache
 import requests
 import toml
+import json
 from cachetools.func import ttl_cache
 from eth_utils import to_checksum_address
 from fastapi import FastAPI, HTTPException
+from typing import Optional
+from constructor_args import do_on_chain_lookup, get_creation_tx, get_creation_code
 
 
 if SENTRY_DSN := os.environ.get("SENTRY_DSN"):
@@ -20,6 +23,14 @@ app = FastAPI()
 cache = diskcache.Cache("cache", statistics=True, size_limit=10e9)
 config = toml.load(open("config.toml"))
 keys = {explorer: cycle(config[explorer]["keys"]) for explorer in config}
+CHAINS = {}
+RPC_URLS = {}
+for explorer in config:
+  if "rpc" not in config[explorer]:
+    continue
+  r = config[explorer]["rpc"]
+  CHAINS[explorer] = r["chain_id"]
+  RPC_URLS[r["chain_id"]] = r["url"]
 
 class ContractNotVerified(HTTPException):
     ...
@@ -113,3 +124,77 @@ def cache_stats():
         "count": count[0],
         "size": cache.volume(),
     }
+
+@app.get("/{explorer}/constructor_args/{address}")
+def constructor_args(
+  explorer: str,
+  address: str,
+  on_chain_lookup: bool=False,
+  creation_tx_hash: Optional[str]=None,
+  bytecode: Optional[str]=None):
+  """
+  Returns the constructor args for a contract provided by ``address``.
+
+  By default, it tries to get the constructor args from the explorer by calling
+  its api.
+
+  For doing on-chain lookups instead, the ``on_chain_lookup`` param can be set to ``True``.
+  On-chain lookup will also be done as a fallback if explorer based lookups fail:
+
+  1. get the creation_code from the creation tx
+  2. compare it with the passed ``bytecode``
+  3. return the last bytes in the diff ``creation_code-bytecode``
+
+  Parameters:
+  ===========
+  :param explorer: the used explorer, e.g. etherscan
+  :param address: the address of the contract
+  :param on_chain_lookup: enables on-chain lookup instead of querying the explorer
+  :param creation_tx_hash: optional hash of the tx when the contract was deployed.
+                           Useful if the provided node can't determine the contract creation tx.
+  :param bytecode: optional hex string of the compiled original source code
+                   Useful if the explorer doesn't return valid constructor args or if they're incorrect.
+
+  :return: a hex string with the constructor args used during deployment of the contract.
+  """
+
+  try:
+      address = to_checksum_address(address)
+  except ValueError:
+      raise HTTPException(400, "invalid address")
+
+  constructor_args = {
+    "address": address,
+  }
+
+  rpc_url = None
+  chain_id = None
+  if explorer in CHAINS:
+      chain_id = CHAINS[explorer]
+      if chain_id not in RPC_URLS:
+          raise HTTPException(404, f"no rpc configured for explorer {explorer}")
+      if RPC_URLS[chain_id] == None:
+          raise HTTPException(404, f"no rpc configured for explorer {explorer}")
+
+      rpc_url = RPC_URLS[chain_id]
+
+  if on_chain_lookup:
+      args = do_on_chain_lookup(explorer, rpc_url, address, creation_tx_hash, bytecode)
+      constructor_args["constructor_args"] = args
+      return constructor_args
+
+  try:
+      res = get_from_upstream(explorer, "contract", "getsourcecode", address)
+  except ContractNotVerified:
+      res = weak_cache(explorer, "contract", "getsourcecode", address)
+  if res["message"] == "OK" and "result" in res:
+      results = res["result"]
+      if len(results) > 0:
+          args = results[0]["ConstructorArguments"]
+
+  if not args:
+    # fallback if explorer api didn't return anything
+    args = do_on_chain_lookup(explorer, rpc_url, address, creation_tx_hash, bytecode)
+
+  constructor_args["constructor_args"] = args
+  return constructor_args

--- a/app.py
+++ b/app.py
@@ -23,14 +23,6 @@ app = FastAPI()
 cache = diskcache.Cache("cache", statistics=True, size_limit=10e9)
 config = toml.load(open("config.toml"))
 keys = {explorer: cycle(config[explorer]["keys"]) for explorer in config}
-CHAINS = {}
-RPC_URLS = {}
-for explorer in config:
-  if "rpc" not in config[explorer]:
-    continue
-  r = config[explorer]["rpc"]
-  CHAINS[explorer] = r["chain_id"]
-  RPC_URLS[r["chain_id"]] = r["url"]
 
 class ContractNotVerified(HTTPException):
     ...
@@ -168,15 +160,8 @@ def constructor_args(
   }
 
   rpc_url = None
-  chain_id = None
-  if explorer in CHAINS:
-      chain_id = CHAINS[explorer]
-      if chain_id not in RPC_URLS:
-          raise HTTPException(404, f"no rpc configured for explorer {explorer}")
-      if RPC_URLS[chain_id] == None:
-          raise HTTPException(404, f"no rpc configured for explorer {explorer}")
-
-      rpc_url = RPC_URLS[chain_id]
+  if "rpc_url" in config[explorer]:
+      rpc_url = config[explorer]["rpc_url"]
 
   if on_chain_lookup:
       args = do_on_chain_lookup(explorer, rpc_url, address, creation_tx_hash, bytecode)

--- a/constructor_args.py
+++ b/constructor_args.py
@@ -1,0 +1,66 @@
+import requests
+import json
+from fastapi import HTTPException
+
+def get_creation_tx(address: str, url: str) -> str:
+  res = requests.post(
+    url,
+    json= {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "ots_getContractCreator",
+      "params": [address]
+    }
+  )
+  if res.status_code != 200:
+    return None
+
+  results = res.json()
+  return results["result"]["hash"]
+
+def get_creation_code(tx: str, url: str) -> str:
+  res = requests.post(
+    url,
+    json= {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "eth_getTransactionByHash",
+      "params": [tx]
+    }
+  )
+  if res.status_code != 200:
+    return None
+
+  results = res.json()
+  return results["result"]["input"]
+
+def do_on_chain_lookup(explorer: str, rpc_url: str, address: str, creation_tx_hash: str, bytecode: str) -> str:
+    if not rpc_url:
+          raise HTTPException(404, f"no rpc configured for explorer {explorer}")
+
+    if not bytecode:
+        raise HTTPException(400, f"no bytecode provided for address {address}")
+
+    if not creation_tx_hash and rpc_url:
+        # this only works for nodes which can determine the creation tx
+        creation_tx_hash = get_creation_tx(address, rpc_url)
+
+    if not creation_tx_hash:
+        raise HTTPException(404, f"creation tx not found for address {address}")
+
+    creation_code = get_creation_code(creation_tx_hash, rpc_url)
+    if not creation_code:
+        raise HTTPException(404, f"creation code not found for tx {creation_tx_hash}")
+
+    # The constructor args are appended at the end of the creation_code.
+    # Substracting the length of the original compiled bytecode will return
+    # the length of the constructor args which we can then use as offset for
+    # slicing the creation_code.
+    length = len(creation_code) - len(bytecode)
+
+    args = ""
+    if length > 0:
+        # return the last "length" bytes from the creation_code
+        args = creation_code[-length:]
+
+    return args

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,9 @@ keys = [
     "0NWN4412GB0X9KNH7XH4220UMB6F28CIIH",
     "UO6F66X8H2NS0ALAJNQIXQP6APO74O0UAU",
 ]
+[etherscan.rpc]
+chain_id = 1
+url = "http://localhost:8545"
 ```
 
 The keys will be used in a round robin manner. All requested sources and ABIs will be forever cached.
@@ -35,6 +38,7 @@ Front with something like Caddy if you need `https`.
 
 - `/{explorer}/api` forwards to upstream api
 - `/stats` cache stats (hits, misses, count, size)
+- `/{explorer}/constructor_args/{address}` returns the bytecode of the constructor args when the contract was deployed
 
 
 ## Docker

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,8 @@ Create a `config.toml`, specify multiple upstreams with their corresponding API 
 ```toml
 [etherscan]
 url = "https://api.etherscan.io/api"
+# optional for on-chain lookups
+# rpc_url = "http://localhost:8545"
 keys = [
     "V53X2WJ37502KMJFXOZB30V0JHNMO11IEO",
     "C6CS0ELHNKQJOL5KUGJVI9UOX3PRECYOZW",
@@ -20,9 +22,6 @@ keys = [
     "0NWN4412GB0X9KNH7XH4220UMB6F28CIIH",
     "UO6F66X8H2NS0ALAJNQIXQP6APO74O0UAU",
 ]
-[etherscan.rpc]
-chain_id = 1
-url = "http://localhost:8545"
 ```
 
 The keys will be used in a round robin manner. All requested sources and ABIs will be forever cached.


### PR DESCRIPTION
## What I did
Added a convenience route to return constructor args:

`/{explorer}/constructor_args/{address}`

By default it will query the explorer's API and return constructor args from there.

It's also possible to override this and do on-chain lookups and comparisons:
1. configure a rpc for the current explorer inside `config.toml`
2. set `on_chain_lookup=true` as query param
3. compile the original source code and pass in the resulting `bytecode` as query param
4. pass in the `creation_tx_hash` or let it be auto-discovered if the rpc supports it

## Why not just always use explorer's API ?
It could be that there's some wrong cached values on the explorer's side or the explorer is down or you just prefer to do an on-chain lookup for doing verifications.